### PR TITLE
fix cargo build warnings

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -35,7 +35,7 @@ fn sample<T: Clone>(xs: Vec<T>, size: usize) -> Vec<T> {
 
     if size > len { return xs }
 
-    let between = Range::new(0usize, (len - size));
+    let between = Range::new(0usize, len - size);
     let mut rng = rand::thread_rng();
     let seed = between.ind_sample(&mut rng);
     let lower = seed;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,6 @@
 #![cfg_attr(feature="clippy", plugin(clippy))]
 
 #[macro_use] extern crate clap;
-#[macro_use] extern crate log;
 extern crate ansi_term;
 extern crate crypto;
 extern crate csv;


### PR DESCRIPTION
This PR gets rid of the following cargo build warnings:

```
warning: unused `#[macro_use]` import
 --> src/main.rs:8:1
  |
8 | #[macro_use] extern crate log;
  | ^^^^^^^^^^^^
  |
  = note: #[warn(unused_imports)] on by default

warning: unnecessary parentheses around function argument
  --> /Users/fuchs/projects/rust/tflgtfs/target/release/build/tflgtfs-7097cd2979d5a043/out/main.rs:38:42
   |
38 |         let between = Range::new(0usize, (len - size));
   |                                          ^^^^^^^^^^^^ help: remove these parentheses
   |
   = note: #[warn(unused_parens)] on by default
```